### PR TITLE
Add brute force option to specify IP, Port, & Protocol.

### DIFF
--- a/leviathan.py
+++ b/leviathan.py
@@ -20,7 +20,7 @@ import glob
 from lib.protocol_scanner import shodan_search, censys_search, mass_scan
 from lib.utils import query_constructor, automatic_dork, show_config_file, \
     config_change, get_file_by_dicovery_id, return_asset
-from lib.brute_forcer import brute_force, bruteforce_all
+from lib.brute_forcer import brute_force, bruteforce_all, brute_force_specific
 from lib.sqli_scanner import sqli_scan, sqli_scan_all, link_extract
 from lib.send_command import send_command_ssh, send_to_all_ssh
 from leviathan_config import COUNTRY_CODES, BASE_DIR
@@ -102,28 +102,28 @@ Select from the menu:
 def menu1():
     print """
 
- _______________          |*\_/*|________ 
-|  ___________  |        ||_/-\_|______  | 
-| |           | |        | |           | | 
-| |   0   0   | |        | |   0   0   | | 
-| |     -     | |        | |     -     | | 
-| |   \___/   | |        | |   \___/   | | 
-| |___     ___| |        | |___________| | 
-|_____|\_/|_____|        |_______________| 
+ _______________          |*\_/*|________
+|  ___________  |        ||_/-\_|______  |
+| |           | |        | |           | |
+| |   0   0   | |        | |   0   0   | |
+| |     -     | |        | |     -     | |
+| |   \___/   | |        | |   \___/   | |
+| |___     ___| |        | |___________| |
+|_____|\_/|_____|        |_______________|
  _|__|/ \|_|_.............._|________|_
-/ ********** \            / ********** \ 
-/ ************ \         / ************ \   
-     _ _                                   
-    | (_)                                  
-  __| |_ ___  ___ _____   _____ _ __ _   _ 
+/ ********** \            / ********** \
+/ ************ \         / ************ \
+     _ _
+    | (_)
+  __| |_ ___  ___ _____   _____ _ __ _   _
  / _` | / __|/ __/ _ \ \ / / _ \ '__| | | |
 | (_| | \__ \ (_| (_) \ V /  __/ |  | |_| |
  \__,_|_|___/\___\___/ \_/ \___|_|   \__, |
                                       __/ |
-                                     |___/ 
-                                 
-Discovery module helps you to identify machines which runs a specific service. 
-You can extract pre-discovered machines with Shodan's or Censys's API (option 1-2) 
+                                     |___/
+
+Discovery module helps you to identify machines which runs a specific service.
+You can extract pre-discovered machines with Shodan's or Censys's API (option 1-2)
 or you can scan them yourself with masscan tool.(option 3)
 
 Also you can discover websites according to a dork from Google. (option 4)
@@ -155,12 +155,12 @@ def shodan():
          .   \    Shodan.io    /               ~^-|--'
               ^.             .^            .      |       +.
                 "-.._____.,-" .                    .
-         +           .                .   +                       
+         +           .                .   +
 
 
-    Shodan module will you to extract pre-discovered machines via Shodan's API. 
+    Shodan module will you to extract pre-discovered machines via Shodan's API.
 
-    In 'Automatic Query' section you can generate Shodan search query and find machines 
+    In 'Automatic Query' section you can generate Shodan search query and find machines
     by providing country code and service type.
 
     In 'Custom Query' section you need to enter your Shodan search query by yourself.
@@ -191,7 +191,7 @@ def shodan_auto_query():
         shodan()
 
     print """
-    Enter Protocol 
+    Enter Protocol
 
     (Examples:ssh, ftp, telnet, smb, rdp, mysql):
     """
@@ -241,12 +241,12 @@ def censys():
          .   \    Censys.io    /               ~^-|--'
               ^.             .^            .      |       +.
                 "-.._____.,-" .                    .
-         +           .                .   +              
+         +           .                .   +
 
 
-    Censys module will you to extract pre-discovered machines via Censys's API. 
+    Censys module will you to extract pre-discovered machines via Censys's API.
 
-    In 'Automatic Query' section you can generate Censys search query and find machines 
+    In 'Automatic Query' section you can generate Censys search query and find machines
     by providing country code and service type.
 
     In 'Custom Query' section you need to enter your Censys search query by yourself.
@@ -278,7 +278,7 @@ def censys_auto_query():
         censys_auto_query()
 
     print """
-        Enter Protocol 
+        Enter Protocol
 
         (Examples:ssh, ftp, telnet):
         """
@@ -335,7 +335,7 @@ def masscan():
     """
     ip_range = raw_input(">>")
     print """
-    Enter Protocol 
+    Enter Protocol
 
     (Examples:ssh, ftp, telnet, smb, rdp, mysql):
     """
@@ -352,12 +352,12 @@ def webscan():
     print """
 
                                  \_______/
-                             `.,-'\_____/`-.,'      
-                              /`..'\ _ /`.,'\     
-                             /  /`.,' `.,'\  \     
-                      WEB   /__/__/     \__\__\__  SCANNER 
+                             `.,-'\_____/`-.,'
+                              /`..'\ _ /`.,'\
+                             /  /`.,' `.,'\  \
+                      WEB   /__/__/     \__\__\__  SCANNER
                             \  \  \     /  /  /
-                             \  \,'`._,'`./  /   
+                             \  \,'`._,'`./  /
                               \,'`./___\,'`./
                              ,'`-./_____\,-'`.
                                  /       \
@@ -466,7 +466,7 @@ def menu2():
     In 'Web(SQL Injection)' section you can search for SQL Injection
     vulnerabilities on pre-discovered URLs
 
-    In 'Custom Exploit' section you can run a custom exploit for 
+    In 'Custom Exploit' section you can run a custom exploit for
     pre-discovered targets.
 
     In 'Run remote command' section you can execute commands remotely
@@ -492,21 +492,24 @@ def bruteforce():
                    -/o\_\  the one that remains, however unlikely,
                  __\_-./   is the right answer." - Sherlock Holmes
                 / / V \`U-.
-    ())        /, > o <    \  
-    <\.,.-._.-" [-\ o /__..-'  
+    ())        /, > o <    \
+    <\.,.-._.-" [-\ o /__..-'
     |/_  ) ) _.-"| \o/  |  \ o!0
-       `'-'-" 
+       `'-'-"
 
 
-    In this section you can make brute force attacks for following
+    In this section you can make brute force attacks for the following
     protocols: ftp, ssh, telnet, rdp, mysql
 
-    You can specifiy your targets by providing discovery id (option 1)
+    You can specify your targets by providing a discovery id (option 1)
 
-    Or you can brute force all discovered targets by providing a protocol (option 2)
+    You can brute force all discovered targets by providing a protocol (option 2)
+
+    Or you can enter an IP address, Port, and Protocol to brute force (option 3)
 
     1)Attack by Discovery id
     2)Attack all discovered machines by Protocol
+    3)Attack specific IP, Port, and Protocol
 
     9. Back
     0. Quit
@@ -557,13 +560,50 @@ def bruteforce_all_menu():
         exec_menu(index, menu4_actions)
 
 
+def bruteforce_specific():
+    print """
+    IP Address:
+    """
+    ip_address = raw_input(">>")
+
+    print """
+    Port Number:
+    """
+    port = raw_input(">>")
+
+    print """
+    Select Protocol:
+
+    1. ftp
+    2. ssh
+    3. telnet
+    4. rdp
+    5. mysql
+
+    9. back
+    0. exit
+
+    """
+    index = raw_input(">>")
+    try:
+        protocol = bruteforce_all_protocols[index]
+        res = brute_force_specific(ip_address, port, protocol)
+        if res:
+            time.sleep(5)
+            main_menu()
+        else:
+            bruteforce()
+    except KeyError:
+        exec_menu(index, menu4_actions)
+
+
 def sqli_menu():
     print """
                   Anatomy of Miroslav Stampar
 
              ___           _,.---,---.,_
             |         ,;~'             '~;,  --- In-band
-            |       ,;                     ;,      
+            |       ,;                     ;,
    First    |      ;                         ; ,--- Error Based
    Order    |     ,'                         /'
             |    ,;                        /' ;, --- Out-of-band
@@ -573,9 +613,9 @@ def sqli_menu():
            |     |  ~  ,-~~~^~, | ,~^~~~-,  ~  |
  Second    |      |   |        }:{        | <------ Boolean Based Blind
   Order    |      |   l       / | \       !   |
-           |      .~  (__,.--" .^. "--.,__)  ~. 
+           |      .~  (__,.--" .^. "--.,__)  ~.
            |      |    ----;' / | \ `;-<--------- Union Based
-           |__     \__.       \/^\/       .__/  
+           |__     \__.       \/^\/       .__/
 
 
         In this section you can search for SQL Injection
@@ -637,7 +677,7 @@ def custom_exploit():
                         `/                         \  /
                         { (+) <Custom Exploits> (+) }'
                          \_________________________/
-    
+
     In "Custom Exploit" section, you can exploit pre-discovered targets.
     Firstly, you need to specifiy your targets by providing a discovery id.
     After then, you need to choose an exploit. Available exploits will be listed
@@ -672,7 +712,7 @@ def custom_exploit():
 def run_command():
     print """
 
-                ,----------------,                ,---------, 
+                ,----------------,                ,---------,
             ,--------------------------,        ,"        ," |
           ,"                       ,"  |       ,"        ,"  |
          +------------------------+ |  |     ,"        ,"    |
@@ -683,12 +723,12 @@ def run_command():
          |  |./dos.pl utkusen.com|  |  |     |==== ooo |      ;
          |  |                    |  |  |     |(((( [33]|    ,"
          |  `--------------------'  |,"      | |((((   |  ,"
-         +-----------------------+  ;;       | |       |,"     
+         +-----------------------+  ;;       | |       |,"
             /_)______________(_/  //'       +.---------+
-       ___________________________/___  
-      /  oooooooooooooooo  .o.  oooo /,   
-     / ==ooooooooooooooo==.o.  ooo= //   
-    /_==__==========__==_ooo__ooo=_/'   
+       ___________________________/___
+      /  oooooooooooooooo  .o.  oooo /,
+     / ==ooooooooooooooo==.o.  ooo= //
+    /_==__==========__==_ooo__ooo=_/'
     `-----------------------------'
 
     In 'Run remote command' section you can execute commands remotely
@@ -745,10 +785,10 @@ def menu3():
          _.-'-' `-'-'|  |`-._/   /    | _ /    .    |
     __.-'            |  |   .   / |_.  | -|_/|/ `--.|_
  --'                  |  | |   /    |  |              `-
-                       |uU |UU/     |  /   
-                                    _       
-                                   | |      
-                  __ _ ___ ___  ___| |_ ___ 
+                       |uU |UU/     |  /
+                                    _
+                                   | |
+                  __ _ ___ ___  ___| |_ ___
                  / _` / __/ __|/ _ | __/ __|
                 | (_| |__ |__ |  __/ |_|__ |
                  |__,_|___/___/|___||__|___/
@@ -853,24 +893,24 @@ def menu4():
     print """
 
 
-                                                 .------.------.    
-  +-------------+                     ___        |      |      |    
-  |             |                     \ /]       |      |      |    
-  | Config Room |        _           _(_)        |      |      |    
-  |             |     ___))         [  | \___    |      |      |    
-  |             |     ) //o          | |     \   |      |      |    
-  |             |  _ (_    >         | |      ]  |      |      |    
-  |          __ | (O)  \__<          | | ____/   '------'------'    
-  |         /  o| [/] /   \)        [__|/_                          
-  |             | [\]|  ( \         __/___\_____                    
-  |             | [/]|   \ \__  ___|            |                   
-  |             | [\]|    \___E/  /|____________|_____              
-  |             | [/]|=====__   (_____________________)             
-  |             | [\] \_____ \    |                  |              
-  |             | [/========\ |   |                  |              
-  |             | [\]     []| |   |                  |              
-  |             | [/]     []| |_  |                  |              
-  |             | [\]     []|___) |                  |             
+                                                 .------.------.
+  +-------------+                     ___        |      |      |
+  |             |                     \ /]       |      |      |
+  | Config Room |        _           _(_)        |      |      |
+  |             |     ___))         [  | \___    |      |      |
+  |             |     ) //o          | |     \   |      |      |
+  |             |  _ (_    >         | |      ]  |      |      |
+  |          __ | (O)  \__<          | | ____/   '------'------'
+  |         /  o| [/] /   \)        [__|/_
+  |             | [\]|  ( \         __/___\_____
+  |             | [/]|   \ \__  ___|            |
+  |             | [\]|    \___E/  /|____________|_____
+  |             | [/]|=====__   (_____________________)
+  |             | [\] \_____ \    |                  |
+  |             | [/========\ |   |                  |
+  |             | [\]     []| |   |                  |
+  |             | [/]     []| |_  |                  |
+  |             | [\]     []|___) |                  |
 ====================================================================
 
     In this section you can change your API keys for Google, Shodan or Censys.
@@ -881,7 +921,7 @@ def menu4():
     4. Censys Secret
     5. Shodan API Key
     6. Show Config File
-    
+
     9. Back
     0. Quit
     """
@@ -904,7 +944,7 @@ def menu4():
     if selected == '9':
         menu4()
     else:
-        exit()    
+        exit()
     return
 
 
@@ -1001,6 +1041,7 @@ menu2_actions = {
 attack_actions = {
     '1': bruteforce_by_discovery_id,
     '2': bruteforce_all_menu,
+    '3': bruteforce_specific,
 
     '9': back,
     '0': exit,

--- a/leviathan.py
+++ b/leviathan.py
@@ -102,28 +102,28 @@ Select from the menu:
 def menu1():
     print """
 
- _______________          |*\_/*|________ 
-|  ___________  |        ||_/-\_|______  | 
-| |           | |        | |           | | 
-| |   0   0   | |        | |   0   0   | | 
-| |     -     | |        | |     -     | | 
-| |   \___/   | |        | |   \___/   | | 
-| |___     ___| |        | |___________| | 
-|_____|\_/|_____|        |_______________| 
+ _______________          |*\_/*|________
+|  ___________  |        ||_/-\_|______  |
+| |           | |        | |           | |
+| |   0   0   | |        | |   0   0   | |
+| |     -     | |        | |     -     | |
+| |   \___/   | |        | |   \___/   | |
+| |___     ___| |        | |___________| |
+|_____|\_/|_____|        |_______________|
  _|__|/ \|_|_.............._|________|_
-/ ********** \            / ********** \ 
-/ ************ \         / ************ \   
-     _ _                                   
-    | (_)                                  
-  __| |_ ___  ___ _____   _____ _ __ _   _ 
+/ ********** \            / ********** \
+/ ************ \         / ************ \
+     _ _
+    | (_)
+  __| |_ ___  ___ _____   _____ _ __ _   _
  / _` | / __|/ __/ _ \ \ / / _ \ '__| | | |
 | (_| | \__ \ (_| (_) \ V /  __/ |  | |_| |
  \__,_|_|___/\___\___/ \_/ \___|_|   \__, |
                                       __/ |
-                                     |___/ 
-                                 
-Discovery module helps you to identify machines which runs a specific service. 
-You can extract pre-discovered machines with Shodan's or Censys's API (option 1-2) 
+                                     |___/
+
+Discovery module helps you to identify machines which runs a specific service.
+You can extract pre-discovered machines with Shodan's or Censys's API (option 1-2)
 or you can scan them yourself with masscan tool.(option 3)
 
 Also you can discover websites according to a dork from Google. (option 4)
@@ -155,12 +155,12 @@ def shodan():
          .   \    Shodan.io    /               ~^-|--'
               ^.             .^            .      |       +.
                 "-.._____.,-" .                    .
-         +           .                .   +                       
+         +           .                .   +
 
 
-    Shodan module will you to extract pre-discovered machines via Shodan's API. 
+    Shodan module will you to extract pre-discovered machines via Shodan's API.
 
-    In 'Automatic Query' section you can generate Shodan search query and find machines 
+    In 'Automatic Query' section you can generate Shodan search query and find machines
     by providing country code and service type.
 
     In 'Custom Query' section you need to enter your Shodan search query by yourself.
@@ -191,7 +191,7 @@ def shodan_auto_query():
         shodan()
 
     print """
-    Enter Protocol 
+    Enter Protocol
 
     (Examples:ssh, ftp, telnet, smb, rdp, mysql):
     """
@@ -241,12 +241,12 @@ def censys():
          .   \    Censys.io    /               ~^-|--'
               ^.             .^            .      |       +.
                 "-.._____.,-" .                    .
-         +           .                .   +              
+         +           .                .   +
 
 
-    Censys module will you to extract pre-discovered machines via Censys's API. 
+    Censys module will you to extract pre-discovered machines via Censys's API.
 
-    In 'Automatic Query' section you can generate Censys search query and find machines 
+    In 'Automatic Query' section you can generate Censys search query and find machines
     by providing country code and service type.
 
     In 'Custom Query' section you need to enter your Censys search query by yourself.
@@ -278,7 +278,7 @@ def censys_auto_query():
         censys_auto_query()
 
     print """
-        Enter Protocol 
+        Enter Protocol
 
         (Examples:ssh, ftp, telnet):
         """
@@ -335,7 +335,7 @@ def masscan():
     """
     ip_range = raw_input(">>")
     print """
-    Enter Protocol 
+    Enter Protocol
 
     (Examples:ssh, ftp, telnet, smb, rdp, mysql):
     """
@@ -352,12 +352,12 @@ def webscan():
     print """
 
                                  \_______/
-                             `.,-'\_____/`-.,'      
-                              /`..'\ _ /`.,'\     
-                             /  /`.,' `.,'\  \     
-                      WEB   /__/__/     \__\__\__  SCANNER 
+                             `.,-'\_____/`-.,'
+                              /`..'\ _ /`.,'\
+                             /  /`.,' `.,'\  \
+                      WEB   /__/__/     \__\__\__  SCANNER
                             \  \  \     /  /  /
-                             \  \,'`._,'`./  /   
+                             \  \,'`._,'`./  /
                               \,'`./___\,'`./
                              ,'`-./_____\,-'`.
                                  /       \
@@ -466,7 +466,7 @@ def menu2():
     In 'Web(SQL Injection)' section you can search for SQL Injection
     vulnerabilities on pre-discovered URLs
 
-    In 'Custom Exploit' section you can run a custom exploit for 
+    In 'Custom Exploit' section you can run a custom exploit for
     pre-discovered targets.
 
     In 'Run remote command' section you can execute commands remotely
@@ -492,19 +492,24 @@ def bruteforce():
                    -/o\_\  the one that remains, however unlikely,
                  __\_-./   is the right answer." - Sherlock Holmes
                 / / V \`U-.
-    ())        /, > o <    \  
-    <\.,.-._.-" [-\ o /__..-'  
+    ())        /, > o <    \
+    <\.,.-._.-" [-\ o /__..-'
     |/_  ) ) _.-"| \o/  |  \ o!0
-       `'-'-" 
+       `'-'-"
 
 
-    In this section you can make brute force attacks for following
+    In this section you can make brute force attacks for the following
     protocols: ftp, ssh, telnet, rdp, mysql
 
-    You can specifiy your targets by providing discovery id (option 1)
+    You can specify your targets by providing a discovery id (option 1)
 
     You can brute force all discovered targets by providing a protocol (option 2)
 
+<<<<<<< a9b7369743a5539576794e3c8a7c958c9c6481d1
+    You can brute force all discovered targets by providing a protocol (option 2)
+
+=======
+>>>>>>> Add Brute Force option to specify IP, Port, & Protocol.
     Or you can enter an IP address, Port, and Protocol to brute force (option 3)
 
     1)Attack by Discovery id
@@ -597,13 +602,50 @@ def bruteforce_all_menu():
         exec_menu(index, menu4_actions)
 
 
+def bruteforce_specific():
+    print """
+    IP Address:
+    """
+    ip_address = raw_input(">>")
+
+    print """
+    Port Number:
+    """
+    port = raw_input(">>")
+
+    print """
+    Select Protocol:
+
+    1. ftp
+    2. ssh
+    3. telnet
+    4. rdp
+    5. mysql
+
+    9. back
+    0. exit
+
+    """
+    index = raw_input(">>")
+    try:
+        protocol = bruteforce_all_protocols[index]
+        res = brute_force_specific(ip_address, port, protocol)
+        if res:
+            time.sleep(5)
+            main_menu()
+        else:
+            bruteforce()
+    except KeyError:
+        exec_menu(index, menu4_actions)
+
+
 def sqli_menu():
     print """
                   Anatomy of Miroslav Stampar
 
              ___           _,.---,---.,_
             |         ,;~'             '~;,  --- In-band
-            |       ,;                     ;,      
+            |       ,;                     ;,
    First    |      ;                         ; ,--- Error Based
    Order    |     ,'                         /'
             |    ,;                        /' ;, --- Out-of-band
@@ -613,9 +655,9 @@ def sqli_menu():
            |     |  ~  ,-~~~^~, | ,~^~~~-,  ~  |
  Second    |      |   |        }:{        | <------ Boolean Based Blind
   Order    |      |   l       / | \       !   |
-           |      .~  (__,.--" .^. "--.,__)  ~. 
+           |      .~  (__,.--" .^. "--.,__)  ~.
            |      |    ----;' / | \ `;-<--------- Union Based
-           |__     \__.       \/^\/       .__/  
+           |__     \__.       \/^\/       .__/
 
 
         In this section you can search for SQL Injection
@@ -677,7 +719,7 @@ def custom_exploit():
                         `/                         \  /
                         { (+) <Custom Exploits> (+) }'
                          \_________________________/
-    
+
     In "Custom Exploit" section, you can exploit pre-discovered targets.
     Firstly, you need to specifiy your targets by providing a discovery id.
     After then, you need to choose an exploit. Available exploits will be listed
@@ -712,7 +754,7 @@ def custom_exploit():
 def run_command():
     print """
 
-                ,----------------,                ,---------, 
+                ,----------------,                ,---------,
             ,--------------------------,        ,"        ," |
           ,"                       ,"  |       ,"        ,"  |
          +------------------------+ |  |     ,"        ,"    |
@@ -723,12 +765,12 @@ def run_command():
          |  |./dos.pl utkusen.com|  |  |     |==== ooo |      ;
          |  |                    |  |  |     |(((( [33]|    ,"
          |  `--------------------'  |,"      | |((((   |  ,"
-         +-----------------------+  ;;       | |       |,"     
+         +-----------------------+  ;;       | |       |,"
             /_)______________(_/  //'       +.---------+
-       ___________________________/___  
-      /  oooooooooooooooo  .o.  oooo /,   
-     / ==ooooooooooooooo==.o.  ooo= //   
-    /_==__==========__==_ooo__ooo=_/'   
+       ___________________________/___
+      /  oooooooooooooooo  .o.  oooo /,
+     / ==ooooooooooooooo==.o.  ooo= //
+    /_==__==========__==_ooo__ooo=_/'
     `-----------------------------'
 
     In 'Run remote command' section you can execute commands remotely
@@ -785,10 +827,10 @@ def menu3():
          _.-'-' `-'-'|  |`-._/   /    | _ /    .    |
     __.-'            |  |   .   / |_.  | -|_/|/ `--.|_
  --'                  |  | |   /    |  |              `-
-                       |uU |UU/     |  /   
-                                    _       
-                                   | |      
-                  __ _ ___ ___  ___| |_ ___ 
+                       |uU |UU/     |  /
+                                    _
+                                   | |
+                  __ _ ___ ___  ___| |_ ___
                  / _` / __/ __|/ _ | __/ __|
                 | (_| |__ |__ |  __/ |_|__ |
                  |__,_|___/___/|___||__|___/
@@ -893,24 +935,24 @@ def menu4():
     print """
 
 
-                                                 .------.------.    
-  +-------------+                     ___        |      |      |    
-  |             |                     \ /]       |      |      |    
-  | Config Room |        _           _(_)        |      |      |    
-  |             |     ___))         [  | \___    |      |      |    
-  |             |     ) //o          | |     \   |      |      |    
-  |             |  _ (_    >         | |      ]  |      |      |    
-  |          __ | (O)  \__<          | | ____/   '------'------'    
-  |         /  o| [/] /   \)        [__|/_                          
-  |             | [\]|  ( \         __/___\_____                    
-  |             | [/]|   \ \__  ___|            |                   
-  |             | [\]|    \___E/  /|____________|_____              
-  |             | [/]|=====__   (_____________________)             
-  |             | [\] \_____ \    |                  |              
-  |             | [/========\ |   |                  |              
-  |             | [\]     []| |   |                  |              
-  |             | [/]     []| |_  |                  |              
-  |             | [\]     []|___) |                  |             
+                                                 .------.------.
+  +-------------+                     ___        |      |      |
+  |             |                     \ /]       |      |      |
+  | Config Room |        _           _(_)        |      |      |
+  |             |     ___))         [  | \___    |      |      |
+  |             |     ) //o          | |     \   |      |      |
+  |             |  _ (_    >         | |      ]  |      |      |
+  |          __ | (O)  \__<          | | ____/   '------'------'
+  |         /  o| [/] /   \)        [__|/_
+  |             | [\]|  ( \         __/___\_____
+  |             | [/]|   \ \__  ___|            |
+  |             | [\]|    \___E/  /|____________|_____
+  |             | [/]|=====__   (_____________________)
+  |             | [\] \_____ \    |                  |
+  |             | [/========\ |   |                  |
+  |             | [\]     []| |   |                  |
+  |             | [/]     []| |_  |                  |
+  |             | [\]     []|___) |                  |
 ====================================================================
 
     In this section you can change your API keys for Google, Shodan or Censys.
@@ -921,7 +963,7 @@ def menu4():
     4. Censys Secret
     5. Shodan API Key
     6. Show Config File
-    
+
     9. Back
     0. Quit
     """
@@ -944,7 +986,7 @@ def menu4():
     if selected == '9':
         menu4()
     else:
-        exit()    
+        exit()
     return
 
 

--- a/leviathan.py
+++ b/leviathan.py
@@ -20,7 +20,7 @@ import glob
 from lib.protocol_scanner import shodan_search, censys_search, mass_scan
 from lib.utils import query_constructor, automatic_dork, show_config_file, \
     config_change, get_file_by_dicovery_id, return_asset
-from lib.brute_forcer import brute_force, bruteforce_all
+from lib.brute_forcer import brute_force, bruteforce_all, brute_force_specific
 from lib.sqli_scanner import sqli_scan, sqli_scan_all, link_extract
 from lib.send_command import send_command_ssh, send_to_all_ssh
 from leviathan_config import COUNTRY_CODES, BASE_DIR
@@ -503,10 +503,13 @@ def bruteforce():
 
     You can specifiy your targets by providing discovery id (option 1)
 
-    Or you can brute force all discovered targets by providing a protocol (option 2)
+    You can brute force all discovered targets by providing a protocol (option 2)
+
+    Or you can enter an IP address, Port, and Protocol to brute force (option 3)
 
     1)Attack by Discovery id
     2)Attack all discovered machines by Protocol
+    3)Attack specific IP, Port, and Protocol
 
     9. Back
     0. Quit
@@ -515,6 +518,43 @@ def bruteforce():
     attack_type = raw_input(">>")
     exec_menu(attack_type, attack_actions)
     return
+
+
+def bruteforce_specific():
+    print """
+    IP Address:
+    """
+    ip_address = raw_input(">>")
+
+    print """
+    Port Number:
+    """
+    port = raw_input(">>")
+
+    print """
+    Select Protocol:
+
+    1. ftp
+    2. ssh
+    3. telnet
+    4. rdp
+    5. mysql
+
+    9. back
+    0. exit
+
+    """
+    index = raw_input(">>")
+    try:
+        protocol = bruteforce_all_protocols[index]
+        res = brute_force_specific(ip_address, port, protocol)
+        if res:
+            time.sleep(5)
+            main_menu()
+        else:
+            bruteforce()
+    except KeyError:
+        exec_menu(index, menu4_actions)
 
 
 def bruteforce_by_discovery_id():
@@ -1001,6 +1041,7 @@ menu2_actions = {
 attack_actions = {
     '1': bruteforce_by_discovery_id,
     '2': bruteforce_all_menu,
+    '3': bruteforce_specific,
 
     '9': back,
     '0': exit,

--- a/leviathan.py
+++ b/leviathan.py
@@ -102,28 +102,28 @@ Select from the menu:
 def menu1():
     print """
 
- _______________          |*\_/*|________
-|  ___________  |        ||_/-\_|______  |
-| |           | |        | |           | |
-| |   0   0   | |        | |   0   0   | |
-| |     -     | |        | |     -     | |
-| |   \___/   | |        | |   \___/   | |
-| |___     ___| |        | |___________| |
-|_____|\_/|_____|        |_______________|
+ _______________          |*\_/*|________ 
+|  ___________  |        ||_/-\_|______  | 
+| |           | |        | |           | | 
+| |   0   0   | |        | |   0   0   | | 
+| |     -     | |        | |     -     | | 
+| |   \___/   | |        | |   \___/   | | 
+| |___     ___| |        | |___________| | 
+|_____|\_/|_____|        |_______________| 
  _|__|/ \|_|_.............._|________|_
-/ ********** \            / ********** \
-/ ************ \         / ************ \
-     _ _
-    | (_)
-  __| |_ ___  ___ _____   _____ _ __ _   _
+/ ********** \            / ********** \ 
+/ ************ \         / ************ \   
+     _ _                                   
+    | (_)                                  
+  __| |_ ___  ___ _____   _____ _ __ _   _ 
  / _` | / __|/ __/ _ \ \ / / _ \ '__| | | |
 | (_| | \__ \ (_| (_) \ V /  __/ |  | |_| |
  \__,_|_|___/\___\___/ \_/ \___|_|   \__, |
                                       __/ |
-                                     |___/
-
-Discovery module helps you to identify machines which runs a specific service.
-You can extract pre-discovered machines with Shodan's or Censys's API (option 1-2)
+                                     |___/ 
+                                 
+Discovery module helps you to identify machines which runs a specific service. 
+You can extract pre-discovered machines with Shodan's or Censys's API (option 1-2) 
 or you can scan them yourself with masscan tool.(option 3)
 
 Also you can discover websites according to a dork from Google. (option 4)
@@ -155,12 +155,12 @@ def shodan():
          .   \    Shodan.io    /               ~^-|--'
               ^.             .^            .      |       +.
                 "-.._____.,-" .                    .
-         +           .                .   +
+         +           .                .   +                       
 
 
-    Shodan module will you to extract pre-discovered machines via Shodan's API.
+    Shodan module will you to extract pre-discovered machines via Shodan's API. 
 
-    In 'Automatic Query' section you can generate Shodan search query and find machines
+    In 'Automatic Query' section you can generate Shodan search query and find machines 
     by providing country code and service type.
 
     In 'Custom Query' section you need to enter your Shodan search query by yourself.
@@ -191,7 +191,7 @@ def shodan_auto_query():
         shodan()
 
     print """
-    Enter Protocol
+    Enter Protocol 
 
     (Examples:ssh, ftp, telnet, smb, rdp, mysql):
     """
@@ -241,12 +241,12 @@ def censys():
          .   \    Censys.io    /               ~^-|--'
               ^.             .^            .      |       +.
                 "-.._____.,-" .                    .
-         +           .                .   +
+         +           .                .   +              
 
 
-    Censys module will you to extract pre-discovered machines via Censys's API.
+    Censys module will you to extract pre-discovered machines via Censys's API. 
 
-    In 'Automatic Query' section you can generate Censys search query and find machines
+    In 'Automatic Query' section you can generate Censys search query and find machines 
     by providing country code and service type.
 
     In 'Custom Query' section you need to enter your Censys search query by yourself.
@@ -278,7 +278,7 @@ def censys_auto_query():
         censys_auto_query()
 
     print """
-        Enter Protocol
+        Enter Protocol 
 
         (Examples:ssh, ftp, telnet):
         """
@@ -335,7 +335,7 @@ def masscan():
     """
     ip_range = raw_input(">>")
     print """
-    Enter Protocol
+    Enter Protocol 
 
     (Examples:ssh, ftp, telnet, smb, rdp, mysql):
     """
@@ -352,12 +352,12 @@ def webscan():
     print """
 
                                  \_______/
-                             `.,-'\_____/`-.,'
-                              /`..'\ _ /`.,'\
-                             /  /`.,' `.,'\  \
-                      WEB   /__/__/     \__\__\__  SCANNER
+                             `.,-'\_____/`-.,'      
+                              /`..'\ _ /`.,'\     
+                             /  /`.,' `.,'\  \     
+                      WEB   /__/__/     \__\__\__  SCANNER 
                             \  \  \     /  /  /
-                             \  \,'`._,'`./  /
+                             \  \,'`._,'`./  /   
                               \,'`./___\,'`./
                              ,'`-./_____\,-'`.
                                  /       \
@@ -466,7 +466,7 @@ def menu2():
     In 'Web(SQL Injection)' section you can search for SQL Injection
     vulnerabilities on pre-discovered URLs
 
-    In 'Custom Exploit' section you can run a custom exploit for
+    In 'Custom Exploit' section you can run a custom exploit for 
     pre-discovered targets.
 
     In 'Run remote command' section you can execute commands remotely
@@ -492,24 +492,19 @@ def bruteforce():
                    -/o\_\  the one that remains, however unlikely,
                  __\_-./   is the right answer." - Sherlock Holmes
                 / / V \`U-.
-    ())        /, > o <    \
-    <\.,.-._.-" [-\ o /__..-'
+    ())        /, > o <    \  
+    <\.,.-._.-" [-\ o /__..-'  
     |/_  ) ) _.-"| \o/  |  \ o!0
-       `'-'-"
+       `'-'-" 
 
 
-    In this section you can make brute force attacks for the following
+    In this section you can make brute force attacks for following
     protocols: ftp, ssh, telnet, rdp, mysql
 
-    You can specify your targets by providing a discovery id (option 1)
+    You can specifiy your targets by providing discovery id (option 1)
 
     You can brute force all discovered targets by providing a protocol (option 2)
 
-<<<<<<< a9b7369743a5539576794e3c8a7c958c9c6481d1
-    You can brute force all discovered targets by providing a protocol (option 2)
-
-=======
->>>>>>> Add Brute Force option to specify IP, Port, & Protocol.
     Or you can enter an IP address, Port, and Protocol to brute force (option 3)
 
     1)Attack by Discovery id
@@ -602,50 +597,13 @@ def bruteforce_all_menu():
         exec_menu(index, menu4_actions)
 
 
-def bruteforce_specific():
-    print """
-    IP Address:
-    """
-    ip_address = raw_input(">>")
-
-    print """
-    Port Number:
-    """
-    port = raw_input(">>")
-
-    print """
-    Select Protocol:
-
-    1. ftp
-    2. ssh
-    3. telnet
-    4. rdp
-    5. mysql
-
-    9. back
-    0. exit
-
-    """
-    index = raw_input(">>")
-    try:
-        protocol = bruteforce_all_protocols[index]
-        res = brute_force_specific(ip_address, port, protocol)
-        if res:
-            time.sleep(5)
-            main_menu()
-        else:
-            bruteforce()
-    except KeyError:
-        exec_menu(index, menu4_actions)
-
-
 def sqli_menu():
     print """
                   Anatomy of Miroslav Stampar
 
              ___           _,.---,---.,_
             |         ,;~'             '~;,  --- In-band
-            |       ,;                     ;,
+            |       ,;                     ;,      
    First    |      ;                         ; ,--- Error Based
    Order    |     ,'                         /'
             |    ,;                        /' ;, --- Out-of-band
@@ -655,9 +613,9 @@ def sqli_menu():
            |     |  ~  ,-~~~^~, | ,~^~~~-,  ~  |
  Second    |      |   |        }:{        | <------ Boolean Based Blind
   Order    |      |   l       / | \       !   |
-           |      .~  (__,.--" .^. "--.,__)  ~.
+           |      .~  (__,.--" .^. "--.,__)  ~. 
            |      |    ----;' / | \ `;-<--------- Union Based
-           |__     \__.       \/^\/       .__/
+           |__     \__.       \/^\/       .__/  
 
 
         In this section you can search for SQL Injection
@@ -719,7 +677,7 @@ def custom_exploit():
                         `/                         \  /
                         { (+) <Custom Exploits> (+) }'
                          \_________________________/
-
+    
     In "Custom Exploit" section, you can exploit pre-discovered targets.
     Firstly, you need to specifiy your targets by providing a discovery id.
     After then, you need to choose an exploit. Available exploits will be listed
@@ -754,7 +712,7 @@ def custom_exploit():
 def run_command():
     print """
 
-                ,----------------,                ,---------,
+                ,----------------,                ,---------, 
             ,--------------------------,        ,"        ," |
           ,"                       ,"  |       ,"        ,"  |
          +------------------------+ |  |     ,"        ,"    |
@@ -765,12 +723,12 @@ def run_command():
          |  |./dos.pl utkusen.com|  |  |     |==== ooo |      ;
          |  |                    |  |  |     |(((( [33]|    ,"
          |  `--------------------'  |,"      | |((((   |  ,"
-         +-----------------------+  ;;       | |       |,"
+         +-----------------------+  ;;       | |       |,"     
             /_)______________(_/  //'       +.---------+
-       ___________________________/___
-      /  oooooooooooooooo  .o.  oooo /,
-     / ==ooooooooooooooo==.o.  ooo= //
-    /_==__==========__==_ooo__ooo=_/'
+       ___________________________/___  
+      /  oooooooooooooooo  .o.  oooo /,   
+     / ==ooooooooooooooo==.o.  ooo= //   
+    /_==__==========__==_ooo__ooo=_/'   
     `-----------------------------'
 
     In 'Run remote command' section you can execute commands remotely
@@ -827,10 +785,10 @@ def menu3():
          _.-'-' `-'-'|  |`-._/   /    | _ /    .    |
     __.-'            |  |   .   / |_.  | -|_/|/ `--.|_
  --'                  |  | |   /    |  |              `-
-                       |uU |UU/     |  /
-                                    _
-                                   | |
-                  __ _ ___ ___  ___| |_ ___
+                       |uU |UU/     |  /   
+                                    _       
+                                   | |      
+                  __ _ ___ ___  ___| |_ ___ 
                  / _` / __/ __|/ _ | __/ __|
                 | (_| |__ |__ |  __/ |_|__ |
                  |__,_|___/___/|___||__|___/
@@ -935,24 +893,24 @@ def menu4():
     print """
 
 
-                                                 .------.------.
-  +-------------+                     ___        |      |      |
-  |             |                     \ /]       |      |      |
-  | Config Room |        _           _(_)        |      |      |
-  |             |     ___))         [  | \___    |      |      |
-  |             |     ) //o          | |     \   |      |      |
-  |             |  _ (_    >         | |      ]  |      |      |
-  |          __ | (O)  \__<          | | ____/   '------'------'
-  |         /  o| [/] /   \)        [__|/_
-  |             | [\]|  ( \         __/___\_____
-  |             | [/]|   \ \__  ___|            |
-  |             | [\]|    \___E/  /|____________|_____
-  |             | [/]|=====__   (_____________________)
-  |             | [\] \_____ \    |                  |
-  |             | [/========\ |   |                  |
-  |             | [\]     []| |   |                  |
-  |             | [/]     []| |_  |                  |
-  |             | [\]     []|___) |                  |
+                                                 .------.------.    
+  +-------------+                     ___        |      |      |    
+  |             |                     \ /]       |      |      |    
+  | Config Room |        _           _(_)        |      |      |    
+  |             |     ___))         [  | \___    |      |      |    
+  |             |     ) //o          | |     \   |      |      |    
+  |             |  _ (_    >         | |      ]  |      |      |    
+  |          __ | (O)  \__<          | | ____/   '------'------'    
+  |         /  o| [/] /   \)        [__|/_                          
+  |             | [\]|  ( \         __/___\_____                    
+  |             | [/]|   \ \__  ___|            |                   
+  |             | [\]|    \___E/  /|____________|_____              
+  |             | [/]|=====__   (_____________________)             
+  |             | [\] \_____ \    |                  |              
+  |             | [/========\ |   |                  |              
+  |             | [\]     []| |   |                  |              
+  |             | [/]     []| |_  |                  |              
+  |             | [\]     []|___) |                  |             
 ====================================================================
 
     In this section you can change your API keys for Google, Shodan or Censys.
@@ -963,7 +921,7 @@ def menu4():
     4. Censys Secret
     5. Shodan API Key
     6. Show Config File
-
+    
     9. Back
     0. Quit
     """
@@ -986,7 +944,7 @@ def menu4():
     if selected == '9':
         menu4()
     else:
-        exit()
+        exit()    
     return
 
 

--- a/leviathan.py
+++ b/leviathan.py
@@ -102,28 +102,28 @@ Select from the menu:
 def menu1():
     print """
 
- _______________          |*\_/*|________
-|  ___________  |        ||_/-\_|______  |
-| |           | |        | |           | |
-| |   0   0   | |        | |   0   0   | |
-| |     -     | |        | |     -     | |
-| |   \___/   | |        | |   \___/   | |
-| |___     ___| |        | |___________| |
-|_____|\_/|_____|        |_______________|
+ _______________          |*\_/*|________ 
+|  ___________  |        ||_/-\_|______  | 
+| |           | |        | |           | | 
+| |   0   0   | |        | |   0   0   | | 
+| |     -     | |        | |     -     | | 
+| |   \___/   | |        | |   \___/   | | 
+| |___     ___| |        | |___________| | 
+|_____|\_/|_____|        |_______________| 
  _|__|/ \|_|_.............._|________|_
-/ ********** \            / ********** \
-/ ************ \         / ************ \
-     _ _
-    | (_)
-  __| |_ ___  ___ _____   _____ _ __ _   _
+/ ********** \            / ********** \ 
+/ ************ \         / ************ \   
+     _ _                                   
+    | (_)                                  
+  __| |_ ___  ___ _____   _____ _ __ _   _ 
  / _` | / __|/ __/ _ \ \ / / _ \ '__| | | |
 | (_| | \__ \ (_| (_) \ V /  __/ |  | |_| |
  \__,_|_|___/\___\___/ \_/ \___|_|   \__, |
                                       __/ |
-                                     |___/
-
-Discovery module helps you to identify machines which runs a specific service.
-You can extract pre-discovered machines with Shodan's or Censys's API (option 1-2)
+                                     |___/ 
+                                 
+Discovery module helps you to identify machines which runs a specific service. 
+You can extract pre-discovered machines with Shodan's or Censys's API (option 1-2) 
 or you can scan them yourself with masscan tool.(option 3)
 
 Also you can discover websites according to a dork from Google. (option 4)
@@ -155,12 +155,12 @@ def shodan():
          .   \    Shodan.io    /               ~^-|--'
               ^.             .^            .      |       +.
                 "-.._____.,-" .                    .
-         +           .                .   +
+         +           .                .   +                       
 
 
-    Shodan module will you to extract pre-discovered machines via Shodan's API.
+    Shodan module will you to extract pre-discovered machines via Shodan's API. 
 
-    In 'Automatic Query' section you can generate Shodan search query and find machines
+    In 'Automatic Query' section you can generate Shodan search query and find machines 
     by providing country code and service type.
 
     In 'Custom Query' section you need to enter your Shodan search query by yourself.
@@ -191,7 +191,7 @@ def shodan_auto_query():
         shodan()
 
     print """
-    Enter Protocol
+    Enter Protocol 
 
     (Examples:ssh, ftp, telnet, smb, rdp, mysql):
     """
@@ -241,12 +241,12 @@ def censys():
          .   \    Censys.io    /               ~^-|--'
               ^.             .^            .      |       +.
                 "-.._____.,-" .                    .
-         +           .                .   +
+         +           .                .   +              
 
 
-    Censys module will you to extract pre-discovered machines via Censys's API.
+    Censys module will you to extract pre-discovered machines via Censys's API. 
 
-    In 'Automatic Query' section you can generate Censys search query and find machines
+    In 'Automatic Query' section you can generate Censys search query and find machines 
     by providing country code and service type.
 
     In 'Custom Query' section you need to enter your Censys search query by yourself.
@@ -278,7 +278,7 @@ def censys_auto_query():
         censys_auto_query()
 
     print """
-        Enter Protocol
+        Enter Protocol 
 
         (Examples:ssh, ftp, telnet):
         """
@@ -335,7 +335,7 @@ def masscan():
     """
     ip_range = raw_input(">>")
     print """
-    Enter Protocol
+    Enter Protocol 
 
     (Examples:ssh, ftp, telnet, smb, rdp, mysql):
     """
@@ -352,12 +352,12 @@ def webscan():
     print """
 
                                  \_______/
-                             `.,-'\_____/`-.,'
-                              /`..'\ _ /`.,'\
-                             /  /`.,' `.,'\  \
-                      WEB   /__/__/     \__\__\__  SCANNER
+                             `.,-'\_____/`-.,'      
+                              /`..'\ _ /`.,'\     
+                             /  /`.,' `.,'\  \     
+                      WEB   /__/__/     \__\__\__  SCANNER 
                             \  \  \     /  /  /
-                             \  \,'`._,'`./  /
+                             \  \,'`._,'`./  /   
                               \,'`./___\,'`./
                              ,'`-./_____\,-'`.
                                  /       \
@@ -466,7 +466,7 @@ def menu2():
     In 'Web(SQL Injection)' section you can search for SQL Injection
     vulnerabilities on pre-discovered URLs
 
-    In 'Custom Exploit' section you can run a custom exploit for
+    In 'Custom Exploit' section you can run a custom exploit for 
     pre-discovered targets.
 
     In 'Run remote command' section you can execute commands remotely
@@ -492,16 +492,16 @@ def bruteforce():
                    -/o\_\  the one that remains, however unlikely,
                  __\_-./   is the right answer." - Sherlock Holmes
                 / / V \`U-.
-    ())        /, > o <    \
-    <\.,.-._.-" [-\ o /__..-'
+    ())        /, > o <    \  
+    <\.,.-._.-" [-\ o /__..-'  
     |/_  ) ) _.-"| \o/  |  \ o!0
-       `'-'-"
+       `'-'-" 
 
 
-    In this section you can make brute force attacks for the following
+    In this section you can make brute force attacks for following
     protocols: ftp, ssh, telnet, rdp, mysql
 
-    You can specify your targets by providing a discovery id (option 1)
+    You can specifiy your targets by providing discovery id (option 1)
 
     You can brute force all discovered targets by providing a protocol (option 2)
 
@@ -597,50 +597,13 @@ def bruteforce_all_menu():
         exec_menu(index, menu4_actions)
 
 
-def bruteforce_specific():
-    print """
-    IP Address:
-    """
-    ip_address = raw_input(">>")
-
-    print """
-    Port Number:
-    """
-    port = raw_input(">>")
-
-    print """
-    Select Protocol:
-
-    1. ftp
-    2. ssh
-    3. telnet
-    4. rdp
-    5. mysql
-
-    9. back
-    0. exit
-
-    """
-    index = raw_input(">>")
-    try:
-        protocol = bruteforce_all_protocols[index]
-        res = brute_force_specific(ip_address, port, protocol)
-        if res:
-            time.sleep(5)
-            main_menu()
-        else:
-            bruteforce()
-    except KeyError:
-        exec_menu(index, menu4_actions)
-
-
 def sqli_menu():
     print """
                   Anatomy of Miroslav Stampar
 
              ___           _,.---,---.,_
             |         ,;~'             '~;,  --- In-band
-            |       ,;                     ;,
+            |       ,;                     ;,      
    First    |      ;                         ; ,--- Error Based
    Order    |     ,'                         /'
             |    ,;                        /' ;, --- Out-of-band
@@ -650,9 +613,9 @@ def sqli_menu():
            |     |  ~  ,-~~~^~, | ,~^~~~-,  ~  |
  Second    |      |   |        }:{        | <------ Boolean Based Blind
   Order    |      |   l       / | \       !   |
-           |      .~  (__,.--" .^. "--.,__)  ~.
+           |      .~  (__,.--" .^. "--.,__)  ~. 
            |      |    ----;' / | \ `;-<--------- Union Based
-           |__     \__.       \/^\/       .__/
+           |__     \__.       \/^\/       .__/  
 
 
         In this section you can search for SQL Injection
@@ -714,7 +677,7 @@ def custom_exploit():
                         `/                         \  /
                         { (+) <Custom Exploits> (+) }'
                          \_________________________/
-
+    
     In "Custom Exploit" section, you can exploit pre-discovered targets.
     Firstly, you need to specifiy your targets by providing a discovery id.
     After then, you need to choose an exploit. Available exploits will be listed
@@ -749,7 +712,7 @@ def custom_exploit():
 def run_command():
     print """
 
-                ,----------------,                ,---------,
+                ,----------------,                ,---------, 
             ,--------------------------,        ,"        ," |
           ,"                       ,"  |       ,"        ,"  |
          +------------------------+ |  |     ,"        ,"    |
@@ -760,12 +723,12 @@ def run_command():
          |  |./dos.pl utkusen.com|  |  |     |==== ooo |      ;
          |  |                    |  |  |     |(((( [33]|    ,"
          |  `--------------------'  |,"      | |((((   |  ,"
-         +-----------------------+  ;;       | |       |,"
+         +-----------------------+  ;;       | |       |,"     
             /_)______________(_/  //'       +.---------+
-       ___________________________/___
-      /  oooooooooooooooo  .o.  oooo /,
-     / ==ooooooooooooooo==.o.  ooo= //
-    /_==__==========__==_ooo__ooo=_/'
+       ___________________________/___  
+      /  oooooooooooooooo  .o.  oooo /,   
+     / ==ooooooooooooooo==.o.  ooo= //   
+    /_==__==========__==_ooo__ooo=_/'   
     `-----------------------------'
 
     In 'Run remote command' section you can execute commands remotely
@@ -822,10 +785,10 @@ def menu3():
          _.-'-' `-'-'|  |`-._/   /    | _ /    .    |
     __.-'            |  |   .   / |_.  | -|_/|/ `--.|_
  --'                  |  | |   /    |  |              `-
-                       |uU |UU/     |  /
-                                    _
-                                   | |
-                  __ _ ___ ___  ___| |_ ___
+                       |uU |UU/     |  /   
+                                    _       
+                                   | |      
+                  __ _ ___ ___  ___| |_ ___ 
                  / _` / __/ __|/ _ | __/ __|
                 | (_| |__ |__ |  __/ |_|__ |
                  |__,_|___/___/|___||__|___/
@@ -930,24 +893,24 @@ def menu4():
     print """
 
 
-                                                 .------.------.
-  +-------------+                     ___        |      |      |
-  |             |                     \ /]       |      |      |
-  | Config Room |        _           _(_)        |      |      |
-  |             |     ___))         [  | \___    |      |      |
-  |             |     ) //o          | |     \   |      |      |
-  |             |  _ (_    >         | |      ]  |      |      |
-  |          __ | (O)  \__<          | | ____/   '------'------'
-  |         /  o| [/] /   \)        [__|/_
-  |             | [\]|  ( \         __/___\_____
-  |             | [/]|   \ \__  ___|            |
-  |             | [\]|    \___E/  /|____________|_____
-  |             | [/]|=====__   (_____________________)
-  |             | [\] \_____ \    |                  |
-  |             | [/========\ |   |                  |
-  |             | [\]     []| |   |                  |
-  |             | [/]     []| |_  |                  |
-  |             | [\]     []|___) |                  |
+                                                 .------.------.    
+  +-------------+                     ___        |      |      |    
+  |             |                     \ /]       |      |      |    
+  | Config Room |        _           _(_)        |      |      |    
+  |             |     ___))         [  | \___    |      |      |    
+  |             |     ) //o          | |     \   |      |      |    
+  |             |  _ (_    >         | |      ]  |      |      |    
+  |          __ | (O)  \__<          | | ____/   '------'------'    
+  |         /  o| [/] /   \)        [__|/_                          
+  |             | [\]|  ( \         __/___\_____                    
+  |             | [/]|   \ \__  ___|            |                   
+  |             | [\]|    \___E/  /|____________|_____              
+  |             | [/]|=====__   (_____________________)             
+  |             | [\] \_____ \    |                  |              
+  |             | [/========\ |   |                  |              
+  |             | [\]     []| |   |                  |              
+  |             | [/]     []| |_  |                  |              
+  |             | [\]     []|___) |                  |             
 ====================================================================
 
     In this section you can change your API keys for Google, Shodan or Censys.
@@ -958,7 +921,7 @@ def menu4():
     4. Censys Secret
     5. Shodan API Key
     6. Show Config File
-
+    
     9. Back
     0. Quit
     """
@@ -981,7 +944,7 @@ def menu4():
     if selected == '9':
         menu4()
     else:
-        exit()
+        exit()    
     return
 
 

--- a/lib/brute_forcer.py
+++ b/lib/brute_forcer.py
@@ -38,18 +38,41 @@ def brute_force(discovery_id):
                 except KeyboardInterrupt:
                     break
                 except:
-                    print "Operation Timeout"    
+                    print "Operation Timeout"
             else:
                 return "Misformatted asset file %s.txt" % discovery_id
 
             print ""
             print "Finished"
+
+
+def brute_force_specific(ip_address, port_number, protocol):
+    cracked_list = []
+
+    port, user_list, pass_list = get_protocol_info(protocol)
+
+    if port_number and user_list and pass_list:
+        user_fullpath = os.path.join(BASE_DIR, 'config', 'wordlists', user_list)
+        pass_fullpath = os.path.join(BASE_DIR, 'config', 'wordlists', pass_list)
+        ip_fullpath = None
+
+        try:
+            brute_force_by_ip(ip_address, user_fullpath, pass_fullpath, ip_fullpath, protocol, port_number)
+        except KeyboardInterrupt:
+            return
+        except:
+            print "Operation Timeout"
+
+        print ""
+        print "Finished"
+
+
 @timeout(50)
 def brute_force_by_ip(ipaddress, user_fullpath, pass_fullpath, ip_fullpath, protocol, port):
     ipaddress = ipaddress.strip("\n")
     print "\nTrying: " +ipaddress
     cmd = get_command(protocol, port, user_fullpath, pass_fullpath, ipaddress)
-    output = check_output(cmd)  
+    output = check_output(cmd)
     output_list = output.split('\n')
     for line in output_list:
         clean_line = line.rstrip()

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -77,7 +77,7 @@ def get_command(protocol, port, user_fullpath, pass_fullpath, ip):
         'telnet': ['ncrack', '-p', port, '-U', user_fullpath, '-P', pass_fullpath, '--pairwise', ip,
                    '-T5']
     }.get(protocol,
-          ['ncrack', '-p', port, '-U', user_fullpath, '-P', pass_fullpath, ip, '-T5']
+          ['ncrack', '-p', '%s:%s' % (protocol, port), '-U', user_fullpath, '-P', pass_fullpath, ip, '-T5']
           )
 
 
@@ -147,7 +147,7 @@ def discovery_parse(discovery_id):
         return []
     except IOError:
         print "There is no such file: %s" % output_file
-        return 0     
+        return 0
 
 
 def get_file_by_dicovery_id(discovery_id, type):
@@ -171,7 +171,7 @@ def compromise_save(discovery_id, exploit_name, asset_list):
                 compromised.write("\n")
     except IOError:
         print "There is no such file: %s" % output_file
-        return 0             
+        return 0
 
 
 def return_asset(protocol, type):
@@ -191,14 +191,14 @@ def return_asset(protocol, type):
 
 def show_config_file():
     print """
-    
+
         GOOGLE_API_KEY = %s
         GOOGLE_CSE_ID = %s
         CENSYS_API_URL = %s
         CENSYS_UID = %s
         CENSYS_SECRET = %s
         SHODAN_API_KEY = %s
-        
+
     """ % (GOOGLE_API_KEY, GOOGLE_CSE_ID, CENSYS_API_URL, CENSYS_UID, CENSYS_SECRET, SHODAN_API_KEY)
     return
 
@@ -229,6 +229,4 @@ def file_len(fname):
                 pass
         return i + 1
     except:
-        return 0    
-
- 
+        return 0


### PR DESCRIPTION
I implemented this option as a means of brute forcing a specific target without having to go through the Discovery process. 

This is an excellent addition as users will no longer be required to scan a host prior to attempting the brute force. I often know all the information about my targets beforehand, so it'd be redundant to perform a scan on them.

To access this new feature, go to `2)Attack -> 1)Brute Force -> 3)Attack specific IP, Port, and Protocol`.

The reason the user must specify both a port number and a protocol is simple; a lot of people use certain protocol services on non-standard ports. Perhaps our target is running OpenSSH on Port 2048, then what? Having the user enter this extra info helps improve the accuracy of the attack.

I hope this pull request proves helpful for others!